### PR TITLE
ci: hard code docker host entry for bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,15 @@ cache:
 - apt
 
 before_install:
-- sudo docker run -d -i -t --name test_container -v ${TRAVIS_BUILD_DIR%${TRAVIS_REPO_SLUG}}:${TRAVIS_BUILD_DIR%${TRAVIS_REPO_SLUG}} laarid/devel:${IMAGE_ARCH} /bin/bash
+- sudo docker pull laarid/devel:${IMAGE_ARCH}
+- sudo docker images
+- |
+  sudo docker run --detach --tty \
+    --name test_container \
+    --volume ${TRAVIS_BUILD_DIR%${TRAVIS_REPO_SLUG}}:${TRAVIS_BUILD_DIR%${TRAVIS_REPO_SLUG}} \
+    --add-host dl.bintray.com:$(nslookup dl.bintray.com | grep -m1 -A1 Name: | grep Address: | awk '{print $2}') \
+    laarid/devel:${IMAGE_ARCH} \
+    /bin/bash
 
 install:
 - ${DOCKER_EXEC_ROOT} apt-get update -qq


### PR DESCRIPTION
Although there has been an hard code step in https://github.com/laarid/docker/pull/10 , Docker regenerates _/etc/hosts_ when creating the container. As a result, specifying an additional host entry is a must.

Also removed `--interactive` flag for it conflicts with `--detach` actually.