### PR TITLE
automake: correct distcheck configure args

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,8 +20,8 @@ MAINTAINERCLEANFILES = \
 # not the docker image architecture as we expected, so specifying the
 # host/build information is necessary here.
 DISTCHECK_CONFIGURE_FLAGS = \
-	--host=$(host) \
-	--build=$(build) \
+	--host=$(host_alias) \
+	--build=$(build_alias) \
 	--disable-maintainer-mode
 
 GITIGNOREFILES = \


### PR DESCRIPTION
According to [automake manual](https://sourceware.org/autobook/autobook/autobook_142.html#Using-the-Target-Type), it's host_alias and build_alias that should be passed as configure --host/--build options. Or, it results in aarch64-unknown-linux-gnu passed and fails searching for cross compiler.